### PR TITLE
Implement exam activity logging

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -77,4 +77,5 @@ $routes->group('api', function ($routes) {
     $routes->post('parse-pdf', 'ApiController::parsePdf');
     $routes->post('grade-answer', 'ApiController::gradeAnswer');
     $routes->get('exam-time-remaining/(:num)', 'ApiController::getTimeRemaining/$1');
+    $routes->post('log-activity', 'ApiController::logActivity');
 });

--- a/app/Controllers/ApiController.php
+++ b/app/Controllers/ApiController.php
@@ -5,18 +5,21 @@ namespace App\Controllers;
 use App\Libraries\OpenAIService;
 use App\Models\ExamModel;
 use App\Models\ExamResultModel;
+use App\Models\ExamActivityLogModel;
 
 class ApiController extends BaseController
 {
     protected $openAIService;
     protected $examModel;
     protected $examResultModel;
+    protected $activityLogModel;
 
     public function __construct()
     {
         $this->openAIService = new OpenAIService();
         $this->examModel = new ExamModel();
         $this->examResultModel = new ExamResultModel();
+        $this->activityLogModel = new ExamActivityLogModel();
     }
 
     public function parsePdf()
@@ -127,5 +130,27 @@ class ApiController extends BaseController
         } else {
             return sprintf('%d menit', $mins);
         }
+    }
+
+    public function logActivity()
+    {
+        $studentId = session()->get('user_id');
+        $examId = $this->request->getPost('exam_id');
+        $eventType = $this->request->getPost('event_type');
+        $details = $this->request->getPost('details');
+
+        if (!$studentId || !$examId || !$eventType) {
+            return $this->response->setJSON(['success' => false, 'message' => 'Invalid data']);
+        }
+
+        $this->activityLogModel->insert([
+            'exam_id' => $examId,
+            'student_id' => $studentId,
+            'event_type' => $eventType,
+            'details' => $details,
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        return $this->response->setJSON(['success' => true]);
     }
 }

--- a/app/Database/Migrations/2025-06-06-203500_CreateExamActivityLogs.php
+++ b/app/Database/Migrations/2025-06-06-203500_CreateExamActivityLogs.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateExamActivityLogs extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => true,
+                'auto_increment' => true,
+            ],
+            'exam_id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => true,
+            ],
+            'student_id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => true,
+            ],
+            'event_type' => [
+                'type' => 'VARCHAR',
+                'constraint' => 50,
+            ],
+            'details' => [
+                'type' => 'TEXT',
+                'null' => true,
+            ],
+            'created_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('exam_activity_logs');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('exam_activity_logs');
+    }
+}

--- a/app/Models/ExamActivityLogModel.php
+++ b/app/Models/ExamActivityLogModel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class ExamActivityLogModel extends Model
+{
+    protected $table = 'exam_activity_logs';
+    protected $primaryKey = 'id';
+    protected $useAutoIncrement = true;
+    protected $returnType = 'array';
+    protected $allowedFields = [
+        'exam_id',
+        'student_id',
+        'event_type',
+        'details',
+        'created_at',
+    ];
+    protected $useTimestamps = false;
+}

--- a/app/Views/student/exam/take.php
+++ b/app/Views/student/exam/take.php
@@ -518,14 +518,40 @@
     window.addEventListener('beforeunload', function(e) {
         e.preventDefault();
         e.returnValue = '';
+        logActivity('page_unload');
     });
 
     // Handle visibility change (user switching tabs/windows)
     document.addEventListener('visibilitychange', function() {
         if (document.hidden) {
             console.warn('User switched away from exam window');
-            // You could implement additional security measures here
+            logActivity('tab_hidden');
+        } else {
+            logActivity('tab_visible');
         }
     });
+
+    document.addEventListener('copy', function() {
+        logActivity('copy');
+    });
+
+    document.addEventListener('paste', function() {
+        logActivity('paste');
+    });
+
+    function logActivity(type, details = '') {
+        fetch('<?= base_url('api/log-activity') ?>', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: JSON.stringify({
+                exam_id: <?= $exam['id'] ?>,
+                event_type: type,
+                details: details
+            })
+        });
+    }
 </script>
 <?= $this->endSection() ?>


### PR DESCRIPTION
## Summary
- create migration for `exam_activity_logs`
- add model `ExamActivityLogModel`
- log suspicious student actions via new API endpoint
- wire route `/api/log-activity`
- send logging events from exam page JavaScript

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_6843505cca388333a7be6f94b2b1cb34