### PR TITLE
Fix exam duration field

### DIFF
--- a/app/Views/admin/exams.php
+++ b/app/Views/admin/exams.php
@@ -91,7 +91,7 @@
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
-                            Duration: <?= $exam['duration'] ?> minutes
+                            Duration: <?= $exam['duration_minutes'] ?> minutes
                         </div>
                         <div class="flex items-center text-sm text-gray-600">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/Views/student/dashboard.php
+++ b/app/Views/student/dashboard.php
@@ -106,7 +106,7 @@
                                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                                     </svg>
-                                    Duration: <?= $exam['duration'] ?> minutes
+                                    Duration: <?= $exam['duration_minutes'] ?> minutes
                                 </div>
                                 <div class="flex items-center text-sm text-gray-600">
                                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/Views/student/exam/take.php
+++ b/app/Views/student/exam/take.php
@@ -263,7 +263,7 @@
 <script>
     let currentQuestion = 1;
     let totalQuestions = <?= count($questions) ?>;
-    let examDuration = <?= $exam['duration'] ?> * 60; // Convert to seconds
+    let examDuration = <?= $exam['duration_minutes'] ?> * 60; // Convert to seconds
     let timeRemaining = examDuration;
     let examTimer;
     let answeredQuestions = new Set(); // Initialize exam


### PR DESCRIPTION
## Summary
- reference `duration_minutes` instead of missing `duration`

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6843f0536868833397b4e8ad84cb0178