### PR TITLE
Introduce ExamResultService for bulk operations

### DIFF
--- a/app/Controllers/Admin/AdminResultController.php
+++ b/app/Controllers/Admin/AdminResultController.php
@@ -3,6 +3,7 @@
 namespace App\Controllers\Admin;
 
 use App\Models\ExamResultModel;
+use App\Services\ExamResultService;
 use App\Models\ExamModel;
 use App\Models\ExamSessionModel;
 use App\Models\ClassModel;
@@ -12,6 +13,7 @@ use CodeIgniter\HTTP\ResponseInterface;
 class AdminResultController extends BaseAdminController
 {
     protected $examResultModel;
+    protected $examResultService;
     protected $examModel;
     protected $examSessionModel;
     protected $classModel;
@@ -20,6 +22,7 @@ class AdminResultController extends BaseAdminController
     {
         parent::__construct();
         $this->examResultModel = new ExamResultModel();
+        $this->examResultService = new ExamResultService();
         $this->examModel = new ExamModel();
         $this->examSessionModel = new ExamSessionModel();
         $this->classModel = new ClassModel();
@@ -204,7 +207,7 @@ class AdminResultController extends BaseAdminController
         }
 
         // Recalculate total score
-        $this->examResultModel->recalculateScore($resultId);
+        $this->examResultService->recalculateScore($resultId);
 
         // Log activity
         $this->logActivity('essay_graded', "Essay untuk hasil ujian ID: {$resultId} telah dinilai");
@@ -226,19 +229,19 @@ class AdminResultController extends BaseAdminController
 
         switch ($action) {
             case 'delete':
-                $result = $this->examResultModel->bulkDelete($resultIds);
+                $result = $this->examResultService->bulkDelete($resultIds);
                 $message = $result ? 'Hasil ujian berhasil dihapus' : 'Gagal menghapus hasil ujian';
                 break;
             case 'publish':
-                $result = $this->examResultModel->bulkPublish($resultIds);
+                $result = $this->examResultService->bulkPublish($resultIds);
                 $message = $result ? 'Hasil ujian berhasil dipublikasi' : 'Gagal mempublikasi hasil ujian';
                 break;
             case 'unpublish':
-                $result = $this->examResultModel->bulkUnpublish($resultIds);
+                $result = $this->examResultService->bulkUnpublish($resultIds);
                 $message = $result ? 'Hasil ujian berhasil disembunyikan' : 'Gagal menyembunyikan hasil ujian';
                 break;
             case 'recalculate':
-                $result = $this->examResultModel->bulkRecalculate($resultIds);
+                $result = $this->examResultService->bulkRecalculate($resultIds);
                 $message = $result ? 'Skor berhasil dihitung ulang' : 'Gagal menghitung ulang skor';
                 break;
             default:

--- a/app/Services/ExamResultService.php
+++ b/app/Services/ExamResultService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ExamResultModel;
+
+class ExamResultService
+{
+    private $examResultModel;
+
+    public function __construct()
+    {
+        $this->examResultModel = new ExamResultModel();
+    }
+
+    /**
+     * Bulk delete exam results
+     */
+    public function bulkDelete(array $resultIds)
+    {
+        return $this->examResultModel->bulkDelete($resultIds);
+    }
+
+    /**
+     * Bulk publish exam results
+     */
+    public function bulkPublish(array $resultIds)
+    {
+        return $this->examResultModel->bulkPublish($resultIds);
+    }
+
+    /**
+     * Bulk unpublish exam results
+     */
+    public function bulkUnpublish(array $resultIds)
+    {
+        return $this->examResultModel->bulkUnpublish($resultIds);
+    }
+
+    /**
+     * Bulk recalculate scores
+     */
+    public function bulkRecalculate(array $resultIds)
+    {
+        return $this->examResultModel->bulkRecalculate($resultIds);
+    }
+
+    /**
+     * Recalculate a single result's score
+     */
+    public function recalculateScore(int $resultId)
+    {
+        return $this->examResultModel->recalculateScore($resultId);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ExamResultService` encapsulating bulk result operations
- inject and use service in `AdminResultController`
- delegate score recalculation and bulk actions to the service

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849237025a483339a8ba6917e9fb006