### PR TITLE
Add service layer for exam result bulk actions

### DIFF
--- a/app/Controllers/Admin/AdminResultController.php
+++ b/app/Controllers/Admin/AdminResultController.php
@@ -378,12 +378,9 @@ class AdminResultController extends BaseAdminController
             return $this->response->setJSON(['success' => false, 'message' => 'Parameter tidak lengkap']);
         }
 
-        $reportData = $this->examResultModel->generateReport($examId, $classId, $reportType);
+        $filename = $this->examResultService->createReport($examId, $classId, $reportType);
 
-        if ($reportData) {
-            // Generate report file
-            $filename = $this->createReportFile($reportData, $reportType);
-
+        if ($filename) {
             return $this->response->setJSON([
                 'success' => true,
                 'message' => 'Laporan berhasil dibuat',
@@ -492,7 +489,7 @@ class AdminResultController extends BaseAdminController
             return $this->response->setJSON(['success' => false, 'message' => 'Session ID tidak valid']);
         }
 
-        if ($this->examResultModel->publishSessionResults($sessionId, $message)) {
+        if ($this->examResultService->publishSessionResults($sessionId, $message)) {
             // Send notification to students
             $this->sendResultNotifications($sessionId);
 

--- a/app/Services/ExamResultService.php
+++ b/app/Services/ExamResultService.php
@@ -52,4 +52,111 @@ class ExamResultService
     {
         return $this->examResultModel->recalculateScore($resultId);
     }
+
+    /**
+     * Publish results of a session
+     */
+    public function publishSessionResults(int $sessionId, ?string $message = null)
+    {
+        return $this->examResultModel->publishSessionResults($sessionId, $message);
+    }
+
+    /**
+     * Generate report file and return filename
+     */
+    public function createReport(int $examId, ?int $classId = null, string $reportType = 'summary')
+    {
+        $data = $this->examResultModel->generateReport($examId, $classId, $reportType);
+
+        if (!$data) {
+            return null;
+        }
+
+        return $this->createReportFile($data, $reportType);
+    }
+
+    private function createReportFile(array $data, string $type)
+    {
+        $filename = 'report_' . $type . '_' . date('Y-m-d_H-i-s') . '.html';
+        $filepath = WRITEPATH . 'uploads/reports/' . $filename;
+
+        if (!is_dir(dirname($filepath))) {
+            mkdir(dirname($filepath), 0777, true);
+        }
+
+        $html = $this->generateReportHTML($data, $type);
+        file_put_contents($filepath, $html);
+
+        return $filename;
+    }
+
+    private function generateReportHTML(array $data, string $type): string
+    {
+        $html = "<!DOCTYPE html>
+        <html>
+        <head>
+            <title>Laporan {$type}</title>
+            <style>
+                body { font-family: Arial, sans-serif; margin: 20px; }
+                .header { text-align: center; margin-bottom: 30px; }
+                .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                .table th, .table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+                .table th { background-color: #f2f2f2; }
+                .stats { display: flex; justify-content: space-around; margin-bottom: 30px; }
+                .stat-box { text-align: center; padding: 15px; border: 1px solid #ddd; border-radius: 5px; }
+            </style>
+        </head>
+        <body>";
+
+        switch ($type) {
+            case 'summary':
+                $html .= $this->generateSummaryReport($data);
+                break;
+            case 'detailed':
+                $html .= $this->generateDetailedReport($data);
+                break;
+            case 'analysis':
+                $html .= $this->generateAnalysisReport($data);
+                break;
+        }
+
+        $html .= "</body></html>";
+
+        return $html;
+    }
+
+    private function generateSummaryReport(array $data): string
+    {
+        $html = "<div class='header'>
+            <h1>Laporan Ringkasan Hasil Ujian</h1>
+            <p>Tanggal: " . date('d/m/Y H:i') . "</p>
+        </div>";
+
+        $html .= "<div class='stats'>
+            <div class='stat-box'>
+                <h3>{$data['total_participants']}</h3>
+                <p>Total Peserta</p>
+            </div>
+            <div class='stat-box'>
+                <h3>{$data['average_score']}</h3>
+                <p>Rata-rata Skor</p>
+            </div>
+            <div class='stat-box'>
+                <h3>{$data['pass_rate']}%</h3>
+                <p>Tingkat Kelulusan</p>
+            </div>
+        </div>";
+
+        return $html;
+    }
+
+    private function generateDetailedReport(array $data): string
+    {
+        return "<h1>Detailed Report</h1>";
+    }
+
+    private function generateAnalysisReport(array $data): string
+    {
+        return "<h1>Analysis Report</h1>";
+    }
 }


### PR DESCRIPTION
## Summary
- extend `ExamResultService` with session publishing and report creation helpers
- delegate report creation and publish actions in `AdminResultController`

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: InvalidArgumentException - missing database seeds)*

------
https://chatgpt.com/codex/tasks/task_b_6849251bcdcc83338e69ccb4bc816075