### PR TITLE
Use constants for exam result statuses

### DIFF
--- a/app/Config/Constants.php
+++ b/app/Config/Constants.php
@@ -77,3 +77,10 @@ defined('EXIT_USER_INPUT')     || define('EXIT_USER_INPUT', 7);     // invalid u
 defined('EXIT_DATABASE')       || define('EXIT_DATABASE', 8);       // database error
 defined('EXIT__AUTO_MIN')      || define('EXIT__AUTO_MIN', 9);      // lowest automatically-assigned error code
 defined('EXIT__AUTO_MAX')      || define('EXIT__AUTO_MAX', 125);    // highest automatically-assigned error code
+
+// --------------------------------------------------------------------
+// Exam Result Status Constants
+// --------------------------------------------------------------------
+defined('EXAM_STATUS_ONGOING')   || define('EXAM_STATUS_ONGOING', 'ongoing');
+defined('EXAM_STATUS_SUBMITTED') || define('EXAM_STATUS_SUBMITTED', 'submitted');
+defined('EXAM_STATUS_GRADED')    || define('EXAM_STATUS_GRADED', 'graded');

--- a/app/Controllers/Admin/AdminAnalyticsController.php
+++ b/app/Controllers/Admin/AdminAnalyticsController.php
@@ -375,7 +375,7 @@ class AdminAnalyticsController extends BaseAdminController
                 ->selectAvg('score')
                 ->where('created_at >=', $startDate)
                 ->where('created_at <=', $endDate)
-                ->where('status', 'graded')
+                ->where('status', EXAM_STATUS_GRADED)
                 ->get()
                 ->getRowArray();
 
@@ -498,7 +498,7 @@ class AdminAnalyticsController extends BaseAdminController
                 ->join('subjects s', 's.id = e.subject_id')
                 ->where('er.created_at >=', $startDate)
                 ->where('er.created_at <=', $endDate)
-                ->where('er.status', 'graded')
+                ->where('er.status', EXAM_STATUS_GRADED)
                 ->groupBy('s.id')
                 ->having('total_attempts >', 0)
                 ->orderBy('average_score', 'DESC')
@@ -534,7 +534,7 @@ class AdminAnalyticsController extends BaseAdminController
                 ->join('classes c', 'c.id = u.class_id')
                 ->where('er.created_at >=', $startDate)
                 ->where('er.created_at <=', $endDate)
-                ->where('er.status', 'graded')
+                ->where('er.status', EXAM_STATUS_GRADED)
                 ->groupBy('c.id')
                 ->having('total_attempts >', 0)
                 ->orderBy('average_score', 'DESC')
@@ -621,7 +621,7 @@ class AdminAnalyticsController extends BaseAdminController
                      MAX(score) as highest_score,                     MIN(score) as lowest_score,
                      STDDEV(score) as score_deviation")
             ->where('exam_id', $examId)
-            ->where('status', 'graded')
+            ->where('status', EXAM_STATUS_GRADED)
             ->get()
             ->getRowArray();
 
@@ -636,7 +636,7 @@ class AdminAnalyticsController extends BaseAdminController
                      END as grade_range,
                      COUNT(*) as count")
             ->where('exam_id', $examId)
-            ->where('status', 'graded')
+            ->where('status', EXAM_STATUS_GRADED)
             ->groupBy('grade_range')
             ->get()
             ->getResultArray();
@@ -666,7 +666,7 @@ class AdminAnalyticsController extends BaseAdminController
             ->join('exams', 'exams.id = exam_results.exam_id')
             ->where('exam_results.created_at >=', $startDate)
             ->where('exam_results.created_at <=', $endDate)
-            ->where('exam_results.status', 'graded')
+            ->where('exam_results.status', EXAM_STATUS_GRADED)
             ->groupBy('exams.id')
             ->orderBy('average_score', 'DESC')
             ->limit(10)
@@ -703,7 +703,7 @@ class AdminAnalyticsController extends BaseAdminController
                      MIN(er.score) as lowest_score")
             ->where('er.created_at >=', $startDate)
             ->where('er.created_at <=', $endDate)
-            ->where('er.status', 'graded')
+            ->where('er.status', EXAM_STATUS_GRADED)
             ->get()
             ->getRowArray();
 
@@ -721,7 +721,7 @@ class AdminAnalyticsController extends BaseAdminController
             ->select("DATE(er.created_at) as date, AVG(er.score) as average_score")
             ->where('er.created_at >=', $startDate)
             ->where('er.created_at <=', $endDate)
-            ->where('er.status', 'graded')
+            ->where('er.status', EXAM_STATUS_GRADED)
             ->groupBy('DATE(er.created_at)')
             ->orderBy('date', 'ASC')
             ->get()

--- a/app/Controllers/Admin/AdminExamController.php
+++ b/app/Controllers/Admin/AdminExamController.php
@@ -436,8 +436,8 @@ class AdminExamController extends BaseAdminController
         // Get exam statistics
         $stats = [
             'total_participants' => $this->examResultModel->where('exam_id', $id)->countAllResults(),
-            'completed_participants' => $this->examResultModel->where('exam_id', $id)->where('status', 'submitted')->countAllResults(),
-            'graded_participants' => $this->examResultModel->where('exam_id', $id)->where('status', 'graded')->countAllResults(),
+            'completed_participants' => $this->examResultModel->where('exam_id', $id)->where('status', EXAM_STATUS_SUBMITTED)->countAllResults(),
+            'graded_participants' => $this->examResultModel->where('exam_id', $id)->where('status', EXAM_STATUS_GRADED)->countAllResults(),
             'average_score' => $this->examResultModel->getAverageScore($id)
         ];
 

--- a/app/Controllers/Admin/AdminReportController.php
+++ b/app/Controllers/Admin/AdminReportController.php
@@ -266,7 +266,7 @@ class AdminReportController extends BaseAdminController
                 $builder->where('exams.id', $filters['exam_id']);
             }
 
-            $builder->where('exam_results.status', 'graded');
+            $builder->where('exam_results.status', EXAM_STATUS_GRADED);
             $builder->orderBy('exam_results.created_at', 'DESC');
 
             $results = $builder->get()->getResultArray();
@@ -325,7 +325,7 @@ class AdminReportController extends BaseAdminController
                 $builder->where('users.class_id', $filters['class_id']);
             }
 
-            $builder->where('exam_results.status', 'graded');
+            $builder->where('exam_results.status', EXAM_STATUS_GRADED);
             $builder->groupBy(['users.id', 'users.name', 'users.email', 'classes.name']);
             $builder->orderBy('average_score', 'DESC');
 
@@ -395,7 +395,7 @@ class AdminReportController extends BaseAdminController
                 $builder->where('exams.id', $filters['exam_id']);
             }
 
-            $builder->where('exam_results.status', 'graded');
+            $builder->where('exam_results.status', EXAM_STATUS_GRADED);
             $builder->groupBy(['exams.id', 'exams.title', 'exams.duration_minutes', 'subjects.name']);
             $builder->orderBy('average_score', 'ASC');
 
@@ -573,7 +573,7 @@ class AdminReportController extends BaseAdminController
             $builder->where('subjects.id', $filters['subject_id']);
         }
 
-        $builder->where('exam_results.status', 'graded');
+        $builder->where('exam_results.status', EXAM_STATUS_GRADED);
         $builder->orderBy('users.name', 'ASC');
         $builder->orderBy('exam_results.created_at', 'ASC');
 
@@ -814,7 +814,7 @@ class AdminReportController extends BaseAdminController
         $builder->join('exams', 'exams.id = exam_results.exam_id');
         $builder->join('subjects', 'subjects.id = exams.subject_id');
         $builder->where('exam_results.student_id', $studentId);
-        $builder->where('exam_results.status', 'graded');
+        $builder->where('exam_results.status', EXAM_STATUS_GRADED);
 
         if (!empty($filters['start_date'])) {
             $builder->where('exam_results.created_at >=', $filters['start_date']);

--- a/app/Controllers/Admin/AdminSubjectController_backup.php
+++ b/app/Controllers/Admin/AdminSubjectController_backup.php
@@ -139,7 +139,7 @@ class AdminSubjectController extends BaseAdminController
             ->join('users u', 'u.id = er.student_id')
             ->join('exams e', 'e.id = er.exam_id')
             ->where('e.subject_id', $id)
-            ->where('er.status', 'graded')
+            ->where('er.status', EXAM_STATUS_GRADED)
             ->groupBy('er.student_id')
             ->orderBy('avg_score', 'DESC')
             ->limit(10)

--- a/app/Controllers/Admin/AdminUserController.php
+++ b/app/Controllers/Admin/AdminUserController.php
@@ -555,7 +555,7 @@ class AdminUserController extends BaseAdminController
             if ($user['role'] === 'student') {
                 $examStats = $this->examResultModel
                     ->where('student_id', $userId)
-                    ->where('status', 'graded')
+                    ->where('status', EXAM_STATUS_GRADED)
                     ->findAll();
 
                 $totalExams = count($examStats);
@@ -627,7 +627,7 @@ class AdminUserController extends BaseAdminController
                 ->join('exams', 'exams.id = exam_results.exam_id')
                 ->join('subjects', 'subjects.id = exams.subject_id')
                 ->where('exam_results.student_id', $userId)
-                ->where('exam_results.status', 'graded')
+                ->where('exam_results.status', EXAM_STATUS_GRADED)
                 ->orderBy('exam_results.submitted_at', 'DESC')
                 ->limit(10)
                 ->findAll();
@@ -674,13 +674,13 @@ class AdminUserController extends BaseAdminController
 
                 $totalExams = count($examResults);
                 $completedExams = count(array_filter($examResults, function ($result) {
-                    return $result['status'] === 'graded';
+                    return $result['status'] === EXAM_STATUS_GRADED;
                 }));
                 $averageScore = 0;
 
                 if ($completedExams > 0) {
                     $gradedResults = array_filter($examResults, function ($result) {
-                        return $result['status'] === 'graded' && $result['percentage'] !== null;
+                        return $result['status'] === EXAM_STATUS_GRADED && $result['percentage'] !== null;
                     });
                     if (count($gradedResults) > 0) {
                         $totalScore = array_sum(array_column($gradedResults, 'percentage'));

--- a/app/Controllers/StudentController.php
+++ b/app/Controllers/StudentController.php
@@ -34,7 +34,7 @@ class StudentController extends BaseController
             'upcomingExams' => $this->examModel->getUpcomingExams(),
             'completedExams' => $this->examResultModel->getResultsByStudent($studentId),
             'totalCompleted' => $this->examResultModel->where('student_id', $studentId)
-                ->where('status', 'graded')
+                ->where('status', EXAM_STATUS_GRADED)
                 ->countAllResults()
         ];
 
@@ -81,7 +81,7 @@ class StudentController extends BaseController
         }
 
         // Check if already submitted
-        if ($examResult['status'] === 'submitted' || $examResult['status'] === 'graded') {
+        if ($examResult['status'] === EXAM_STATUS_SUBMITTED || $examResult['status'] === EXAM_STATUS_GRADED) {
             session()->setFlashdata('info', 'Anda sudah menyelesaikan ujian ini.');
             return redirect()->to('/student/result-detail/' . $examId);
         }
@@ -144,7 +144,7 @@ class StudentController extends BaseController
             return $this->response->setJSON(['success' => false, 'message' => 'Data ujian tidak ditemukan']);
         }
 
-        if ($examResult['status'] === 'submitted' || $examResult['status'] === 'graded') {
+        if ($examResult['status'] === EXAM_STATUS_SUBMITTED || $examResult['status'] === EXAM_STATUS_GRADED) {
             return $this->response->setJSON(['success' => false, 'message' => 'Ujian sudah diselesaikan']);
         }        // Submit exam
         if ($this->examResultModel->submitExam($examId, $studentId)) {

--- a/app/Models/AnalyticsModel.php
+++ b/app/Models/AnalyticsModel.php
@@ -229,7 +229,7 @@ class AnalyticsModel extends Model
             $builder->where('er.created_at <=', $endDate);
         }
 
-        $builder->where('er.status', 'graded');
+        $builder->where('er.status', EXAM_STATUS_GRADED);
         $builder->groupBy('grade_range');
         $builder->orderBy('AVG(er.score)', 'DESC');
 
@@ -273,7 +273,7 @@ class AnalyticsModel extends Model
             $builder->where('er.created_at <=', $endDate);
         }
 
-        $builder->where('er.status', 'graded');
+        $builder->where('er.status', EXAM_STATUS_GRADED);
         $builder->groupBy(['u.id', 'u.name', 'u.email', 'c.name']);
         $builder->orderBy('average_score', 'DESC');
 
@@ -309,7 +309,7 @@ class AnalyticsModel extends Model
             $builder->where('er.created_at <=', $endDate);
         }
 
-        $builder->where('er.status', 'graded');
+        $builder->where('er.status', EXAM_STATUS_GRADED);
         $builder->groupBy(['s.id', 's.name', 's.code']);
         $builder->orderBy('average_score', 'DESC');
 
@@ -347,7 +347,7 @@ class AnalyticsModel extends Model
             $builder->where('e.id', $examId);
         }
 
-        $builder->where('er.status', 'graded');
+        $builder->where('er.status', EXAM_STATUS_GRADED);
         $builder->groupBy(['e.id', 'e.title', 'e.total_questions', 'e.duration_minutes']);
         $builder->orderBy('average_score', 'ASC');
 
@@ -384,7 +384,7 @@ class AnalyticsModel extends Model
             $builder->where('er.created_at <=', $endDate);
         }
 
-        $builder->where('er.status', 'graded');
+        $builder->where('er.status', EXAM_STATUS_GRADED);
         $builder->groupBy("DATE_FORMAT(er.created_at, '{$dateFormat}')");
         $builder->orderBy('period', 'ASC');
 

--- a/app/Models/ExamResultModel.php
+++ b/app/Models/ExamResultModel.php
@@ -68,7 +68,7 @@ class ExamResultModel extends Model
             $data = [
                 'exam_id' => $examId,
                 'student_id' => $studentId,
-                'status' => 'ongoing',
+                'status' => EXAM_STATUS_ONGOING,
                 'started_at' => date('Y-m-d H:i:s')
             ];
             $this->insert($data);
@@ -85,7 +85,7 @@ class ExamResultModel extends Model
         return $this->where('exam_id', $examId)
             ->where('student_id', $studentId)
             ->set([
-                'status' => 'submitted',
+                'status' => EXAM_STATUS_SUBMITTED,
                 'submitted_at' => date('Y-m-d H:i:s')
             ])
             ->update();
@@ -101,7 +101,7 @@ class ExamResultModel extends Model
                 'total_score' => $totalScore,
                 'max_total_score' => $maxTotalScore,
                 'percentage' => $percentage,
-                'status' => 'graded',
+                'status' => EXAM_STATUS_GRADED,
                 'graded_at' => date('Y-m-d H:i:s')
             ])
             ->update();
@@ -111,7 +111,7 @@ class ExamResultModel extends Model
     {
         $result = $this->select('AVG(percentage) as average_score')
             ->where('exam_id', $examId)
-            ->where('status', 'graded')
+            ->where('status', EXAM_STATUS_GRADED)
             ->where('percentage IS NOT NULL')
             ->first();
 
@@ -213,19 +213,19 @@ class ExamResultModel extends Model
     }
     public function getResultStatistics($filters = [])
     {
-        $builder = $this->select('
-                COUNT(*) as total_results,
-                COUNT(CASE WHEN exam_results.status = "graded" THEN 1 END) as graded_count,
-                COUNT(CASE WHEN exam_results.status = "ongoing" THEN 1 END) as ongoing_count,
-                COUNT(CASE WHEN exam_results.status = "submitted" THEN 1 END) as submitted_count,
-                AVG(CASE WHEN exam_results.status = "graded" AND exam_results.percentage IS NOT NULL THEN exam_results.percentage END) as average_score,
-                MAX(CASE WHEN exam_results.status = "graded" AND exam_results.percentage IS NOT NULL THEN exam_results.percentage END) as highest_score,
-                MIN(CASE WHEN exam_results.status = "graded" AND exam_results.percentage IS NOT NULL THEN exam_results.percentage END) as lowest_score,
+        $builder = $this->select(
+                "COUNT(*) as total_results,
+                COUNT(CASE WHEN exam_results.status = '" . EXAM_STATUS_GRADED . "' THEN 1 END) as graded_count,
+                COUNT(CASE WHEN exam_results.status = '" . EXAM_STATUS_ONGOING . "' THEN 1 END) as ongoing_count,
+                COUNT(CASE WHEN exam_results.status = '" . EXAM_STATUS_SUBMITTED . "' THEN 1 END) as submitted_count,
+                AVG(CASE WHEN exam_results.status = '" . EXAM_STATUS_GRADED . "' AND exam_results.percentage IS NOT NULL THEN exam_results.percentage END) as average_score,
+                MAX(CASE WHEN exam_results.status = '" . EXAM_STATUS_GRADED . "' AND exam_results.percentage IS NOT NULL THEN exam_results.percentage END) as highest_score,
+                MIN(CASE WHEN exam_results.status = '" . EXAM_STATUS_GRADED . "' AND exam_results.percentage IS NOT NULL THEN exam_results.percentage END) as lowest_score,
                 COUNT(CASE WHEN exam_results.percentage >= 80 THEN 1 END) as excellent_count,
                 COUNT(CASE WHEN exam_results.percentage >= 70 AND exam_results.percentage < 80 THEN 1 END) as good_count,
                 COUNT(CASE WHEN exam_results.percentage >= 60 AND exam_results.percentage < 70 THEN 1 END) as satisfactory_count,
-                COUNT(CASE WHEN exam_results.percentage < 60 THEN 1 END) as needs_improvement_count
-            ')->join('users', 'users.id = exam_results.student_id')
+                COUNT(CASE WHEN exam_results.percentage < 60 THEN 1 END) as needs_improvement_count"
+            )->join('users', 'users.id = exam_results.student_id')
             ->join('exams', 'exams.id = exam_results.exam_id')
             ->join('subjects', 'subjects.id = exams.subject_id')
             ->join('user_classes', 'user_classes.user_id = users.id', 'left')
@@ -557,7 +557,7 @@ class ExamResultModel extends Model
             'total_score' => $totalScore,
             'max_total_score' => $maxTotalScore,
             'percentage' => round($percentage, 2),
-            'status' => 'graded',
+            'status' => EXAM_STATUS_GRADED,
             'graded_at' => date('Y-m-d H:i:s')
         ]);
     }


### PR DESCRIPTION
## Summary
- define exam result status constants
- reference new constants in `ExamResultModel`
- update controllers to use constants instead of string values
- adjust analytics queries for new constants

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6849236fb5708333b90a460469640b41